### PR TITLE
On failure to process webhook report 400 bad request instead of 404

### DIFF
--- a/CRM/Airmail/Page/Webhook.php
+++ b/CRM/Airmail/Page/Webhook.php
@@ -32,7 +32,7 @@ class CRM_Airmail_Page_Webhook extends CRM_Core_Page {
    * What should happen if we want to reject the message without processing it.
    */
   protected function invalidMessage() {
-    CRM_Utils_System::setHttpHeader("Status", "404 Not Found");
+    http_response_code(400);
     CRM_Utils_System::civiExit();
   }
 


### PR DESCRIPTION
404 is the wrong response here as the webhook is responding, it's just failing to process because it is being access incorrectly.  400 is normally correct in this situation (as used by Stripe etc).