### PR TITLE
issues/4 swap Utils with EventAction

### DIFF
--- a/CRM/Airmail/Backend/Sendgrid.php
+++ b/CRM/Airmail/Backend/Sendgrid.php
@@ -59,7 +59,7 @@ class CRM_Airmail_Backend_Sendgrid implements CRM_Airmail_Backend {
 
         case 'click':
           $params['url'] = $event->url;
-          CRM_Airmail_Utils::click($params);
+          CRM_Airmail_EventAction::click($params);
           break;
       }
     }


### PR DESCRIPTION
As Andrew pointed out in #4 , it appears the click method is in fact in the CRM_Airmail_EventAction instead. Tested very briefly and this fix appears to resolve constant logs on my test site.