### PR TITLE
use Civi::settings not Civi::cache for settings

### DIFF
--- a/CRM/Airmail/Backend/Ses.php
+++ b/CRM/Airmail/Backend/Ses.php
@@ -32,10 +32,6 @@ class CRM_Airmail_Backend_Ses implements CRM_Airmail_Backend {
       case 'Notification':
         // If the message is a notification of a mailing event
         $responseMessage = json_decode($events->Message);
-        CRM_Core_Error::debug_log_message(
-          "SES DEBUG POST\n" . file_get_contents('php://input'),
-          'airmail'
-        );
 
         if (!empty($responseMessage->mail->headers)) {
           foreach ($responseMessage->mail->headers as $header) {

--- a/CRM/Airmail/Page/Webhook.php
+++ b/CRM/Airmail/Page/Webhook.php
@@ -5,7 +5,7 @@ class CRM_Airmail_Page_Webhook extends CRM_Core_Page {
 
   public function run() {
 
-    $settings = Civi::cache()->get('airmailSettings');
+    $settings = CRM_Airmail_Utils::getSettings();
     if (!empty($settings['secretcode']) && $settings['secretcode'] !== ($_GET['secretcode'] ?? '')) {
       $this->invalidMessage();
     }

--- a/CRM/Airmail/Utils.php
+++ b/CRM/Airmail/Utils.php
@@ -119,27 +119,14 @@ class CRM_Airmail_Utils {
    *   The key is the setting name and the value is value of setting
    */
   public static function getSettings() {
-    $settings = Civi::cache()->get('airmailSettings');
-    if (empty($settings)) {
-      $settings = array(
-        'secretcode' => NULL,
-        'external_smtp_service' => NULL,
-        'ee_wrapunsubscribe' => NULL,
-        'ee_unsubscribe' => NULL,
-      );
-      foreach (array_keys($settings) as $setting) {
-        try {
-          $settings[$setting] = civicrm_api3('Setting', 'getvalue', array(
-            'name'  => "airmail_$setting",
-            'group' => 'Airmail Preferences',
-          ));
-        }
-        catch (CiviCRM_API3_Exception $e) {
-          $error = $e->getMessage();
-          CRM_Core_Error::debug_log_message(self::ts('API Error: %1', [1 => $error]));
-        }
-      }
-      Civi::cache()->set('airmailSettings', $settings);
+    $settings = [
+      'secretcode' => NULL,
+      'external_smtp_service' => NULL,
+      'ee_wrapunsubscribe' => NULL,
+      'ee_unsubscribe' => NULL,
+    ];
+    foreach (array_keys($settings) as $setting) {
+      $settings[$setting] = Civi::settings()->get("airmail_{$setting}");
     }
     return $settings;
   }
@@ -151,24 +138,9 @@ class CRM_Airmail_Utils {
    *   The settings to save.
    */
   public static function saveSettings($settings) {
-
-    // Get all settings: if they are cached then we'll need to update.
-    $cachedSettings = Civi::cache()->get('airmailSettings');
-    $settingsToSave = array();
     foreach ($settings as $k => $v) {
-      $settingsToSave["airmail_$k"] = $v;
+      Civi::settings()->set("airmail_{$k}", $v);
     }
-    try {
-      civicrm_api3('Setting', 'create', $settingsToSave);
-      // As that was successful, update our cached value.
-      $cachedSettings[$k] = $v;
-    }
-    catch (CiviCRM_API3_Exception $e) {
-      $error = $e->getMessage();
-      CRM_Core_Error::debug_log_message(self::ts('API Error: %1', [1 => $error]));
-    }
-    // Save our (possibly) updated cached values.
-    Civi::cache()->set('airmailSettings', $cachedSettings);
   }
 
   /**


### PR DESCRIPTION
cacheCurrently, Airmail uses `Civi::cache()` for settings, mailing IDs and mailing jobs.  On a multi-site, the last two are the same across domains, but settings are per-site.  This leads to errors when loading/saving settings on child sites.

Moreover, `Civi::settings()` is already cached, so I was able to cut down the `getSettings()` and `saveSettings()` code considerably, and Airmail now works on multi-site installations.

I also took out some debug code from #14.

PS - The docs for SES setup are out of date again with SESv2, though good enough to muddle through.  If I get around to updating them, I'll also make a note for multi-site installs that all sites must have the same bounce "address" as the first site.