### PR TITLE
sendgrid can't validate messages

### DIFF
--- a/CRM/Airmail/Backend/Sendgrid.php
+++ b/CRM/Airmail/Backend/Sendgrid.php
@@ -5,7 +5,7 @@ use CRM_Airmail_Utils as E;
 class CRM_Airmail_Backend_Sendgrid implements CRM_Airmail_Backend {
 
   public function processInput($input) {
-    return json_decode($input);
+    return json_decode($input, TRUE);
   }
 
   public function validateMessages($events) {


### PR DESCRIPTION
`json_decode()` returns `stdObject` unless you pass `TRUE` as its second argument.  Right after `processInput()` is called, `validateMessages()` is called to ensure we have an array.  Which we don't.  So now we do.