### PR TITLE
They renamed the "Event Notification" to  "Event Webhook" I guess

### DIFF
--- a/docs/Sendgrid.md
+++ b/docs/Sendgrid.md
@@ -1,3 +1,3 @@
 # SendGrid Specific Configuration
 ## Settings in SendGrid
-Log in to SendGrid go to Settings -> Mail Settings -> Event Notification and configure the HTTP post URL to be the post URL and select the actions you would like reported back to your system we recommend: Opened, Clicked, Mark as Span, Unsubscribed From, Dropped, Bounced.
+Log in to SendGrid go to Settings -> Mail Settings -> Event Webhook (https://app.sendgrid.com/settings/mail_settings/webhook_settings) and configure the HTTP post URL to be the post URL and select the actions you would like reported back to your system we recommend: Opened, Clicked, Mark as Span, Unsubscribed From, Dropped, Bounced.


### PR DESCRIPTION
It is here now: https://app.sendgrid.com/settings/mail_settings/webhook_settings